### PR TITLE
Fix conflict between expected changed files and git dirty files

### DIFF
--- a/lib/fastlane/plugin/commit_android_version_bump/actions/commit_android_version_bump_action.rb
+++ b/lib/fastlane/plugin/commit_android_version_bump/actions/commit_android_version_bump_action.rb
@@ -12,10 +12,13 @@ module Fastlane
             UI.message("The commit_android_version_bump plugin will use gradle file at (#{build_file_folder})!")
 
             absolute_path = File.expand_path(build_file_folder)
-            build_file_path = build_file_folder+"/build.gradle"
+            build_file_path = absolute_path + "/build.gradle"
+
             # find the repo root path
             repo_path = Actions.sh("git -C #{absolute_path} rev-parse --show-toplevel").strip
             repo_pathname = Pathname.new(repo_path)
+
+            build_file_path.replace build_file_path.sub("#{repo_pathname}/", "")
         else
             app_folder_name ||= params[:app_folder_name]
             UI.message("The commit_android_version_bump plugin is looking inside your project folder (#{app_folder_name})!")


### PR DESCRIPTION
For a Flutter project, specifying gradle_file_folder as "app" in the
lane config would lead to the following expected changed files
"app/build.gradle" whereas the git dirty file would actually be
"android/app/build.gradle".

This happens because the git root is not the android directory but the
flutter project folder which contains the android project in the
"android" directory.