### PR TITLE
Add "message" to the example Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,6 @@
 lane :test do
   commit_android_version_bump(
-    gradle_file_folder:"project"
+    gradle_file_folder:"project",
+    # message: "Custom git commit message"
   )
 end


### PR DESCRIPTION
An optional "message" property can be passed in containing a custom git commit message.